### PR TITLE
Early stopping

### DIFF
--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -34,7 +34,7 @@ class MetricsFedAvg(FedAvg):
         self.tshark_process = None
         self.early_stop = False
         self.best_loss = float('inf')
-        self.patience = 10
+        self.patience = 5
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -33,7 +33,7 @@ class MetricsFedAvg(FedAvg):
         self.enable_wandb = enable_wandb
         self.tshark_process = None
         self.early_stop = False
-        self.last_loss = 0.0
+        self.last_loss = 100
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -95,8 +95,8 @@ class MetricsFedAvg(FedAvg):
     def aggregate_fit(self, server_round, results, failures):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
-        self.last_loss = metrics['val_loss']
         logger.info(f"Server round {server_round} finished with loss {self.last_loss}")
+        self.last_loss = metrics['val_loss']
         if metrics['val_loss'] > self.last_loss:
             logger.info(f"Early stopping at round {server_round} due to loss threshold.")
             self.early_stop = True

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -32,6 +32,8 @@ class MetricsFedAvg(FedAvg):
         self.run_id = run_id
         self.enable_wandb = enable_wandb
         self.tshark_process = None
+        self.early_stop = False
+        self.loss_threshold = 1.0
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:
@@ -93,9 +95,14 @@ class MetricsFedAvg(FedAvg):
     def aggregate_fit(self, server_round, results, failures):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
+        if metrics['val_loss'] < self.loss_threshold:
+            logger.info(f"Early stopping at round {server_round} due to loss threshold.")
+            self.early_stop = True
         return params, metrics
 
     def configure_fit(self, server_round: int, parameters: Parameters, client_manager: ClientManager) -> list[tuple[ClientProxy, FitIns]]:
+        if self.early_stop:
+            return []
         client_fitins_list = super().configure_fit(server_round, parameters, client_manager)
         update_client_fitins = []
         for client, fit_ins in client_fitins_list:

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -96,7 +96,6 @@ class MetricsFedAvg(FedAvg):
     def aggregate_fit(self, server_round, results, failures):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
-        logger.info(f"Server round {server_round} finished with loss {self.last_loss}")
         if metrics['val_loss'] < self.best_loss:
             self.best_loss = metrics['val_loss']
             self.patience = 10

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -96,6 +96,7 @@ class MetricsFedAvg(FedAvg):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
         self.last_loss = metrics['val_loss']
+        logger.info(f"Server round {server_round} finished with loss {self.last_loss}")
         if metrics['val_loss'] > self.last_loss:
             logger.info(f"Early stopping at round {server_round} due to loss threshold.")
             self.early_stop = True

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -33,7 +33,7 @@ class MetricsFedAvg(FedAvg):
         self.enable_wandb = enable_wandb
         self.tshark_process = None
         self.early_stop = False
-        self.loss_threshold = 1.0
+        self.last_loss = None
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:
@@ -95,7 +95,8 @@ class MetricsFedAvg(FedAvg):
     def aggregate_fit(self, server_round, results, failures):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
-        if metrics['val_loss'] < self.loss_threshold:
+        self.last_loss = metrics['val_loss']
+        if metrics['val_loss'] > self.last_loss:
             logger.info(f"Early stopping at round {server_round} due to loss threshold.")
             self.early_stop = True
         return params, metrics

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -33,7 +33,8 @@ class MetricsFedAvg(FedAvg):
         self.enable_wandb = enable_wandb
         self.tshark_process = None
         self.early_stop = False
-        self.last_loss = 100
+        self.best_loss = float('inf')
+        self.patience = 10
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:
@@ -96,10 +97,14 @@ class MetricsFedAvg(FedAvg):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
         logger.info(f"Server round {server_round} finished with loss {self.last_loss}")
-        if metrics['val_loss'] > self.last_loss:
-            logger.info(f"Early stopping at round {server_round} due to loss threshold.")
-            self.early_stop = True
-        self.last_loss = metrics['val_loss']
+        if metrics['val_loss'] < self.best_loss:
+            self.best_loss = metrics['val_loss']
+            self.patience = 10
+        else:
+            self.patience -= 1
+            if self.patience == 0:
+                self.early_stop = True
+                logger.info(f"Early stopping at round {server_round} due to loss threshold.")
         return params, metrics
 
     def configure_fit(self, server_round: int, parameters: Parameters, client_manager: ClientManager) -> list[tuple[ClientProxy, FitIns]]:

--- a/flwr-application/federated_application/strategy.py
+++ b/flwr-application/federated_application/strategy.py
@@ -33,7 +33,7 @@ class MetricsFedAvg(FedAvg):
         self.enable_wandb = enable_wandb
         self.tshark_process = None
         self.early_stop = False
-        self.last_loss = None
+        self.last_loss = 0.0
         self.dir_name = f'server.{self.clients}C.{self.epochs}E.{self.batch_size}B.{self.num_rounds}R-{self.init_time}'
 
         if enable_wandb:
@@ -96,10 +96,10 @@ class MetricsFedAvg(FedAvg):
         params, metrics = super().aggregate_fit(server_round, results, failures)
         self._log_results(server_round, metrics)
         logger.info(f"Server round {server_round} finished with loss {self.last_loss}")
-        self.last_loss = metrics['val_loss']
         if metrics['val_loss'] > self.last_loss:
             logger.info(f"Early stopping at round {server_round} due to loss threshold.")
             self.early_stop = True
+        self.last_loss = metrics['val_loss']
         return params, metrics
 
     def configure_fit(self, server_round: int, parameters: Parameters, client_manager: ClientManager) -> list[tuple[ClientProxy, FitIns]]:


### PR DESCRIPTION
This pull request introduces an early stopping mechanism to the federated learning strategy in the `flwr-application`. The changes include adding new attributes to track early stopping criteria and modifying the logging and configuration methods to implement the early stopping logic.

Early stopping mechanism:

* [`flwr-application/federated_application/strategy.py`](diffhunk://#diff-1dfa0bb83fd370c9339da0d800f322154c31b773e9c405ce9062b865b1e71542R35-R37): Added `early_stop`, `best_loss`, and `patience` attributes to the `__init__` method to initialize early stopping parameters.
* [`flwr-application/federated_application/strategy.py`](diffhunk://#diff-1dfa0bb83fd370c9339da0d800f322154c31b773e9c405ce9062b865b1e71542R99-R111): Updated the `_log_results` method to check the validation loss against the best loss and adjust the patience counter. If the patience counter reaches zero, early stopping is triggered, and a log message is recorded.
* [`flwr-application/federated_application/strategy.py`](diffhunk://#diff-1dfa0bb83fd370c9339da0d800f322154c31b773e9c405ce9062b865b1e71542R99-R111): Modified the `configure_fit` method to return an empty list if early stopping is triggered, effectively halting further training rounds.