### PR TITLE
fix transfer, fix version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update && apt install -y \
     build-essential
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
-RUN pip install /app/dist/flwr-1.18.0-py3-none-any.whl
+RUN pip install /app/dist/flwr-1.15.2-py3-none-any.whl
 
 ENV PYTHONPATH=/app
 

--- a/helper_scripts/transfer_latency_measurements.sh
+++ b/helper_scripts/transfer_latency_measurements.sh
@@ -20,6 +20,6 @@ for ((CID=1;CID<=NUM_CLIENTS;CID++)); do
     NEW_FILE_NAME="${FILE_NAME%.csv}_CID${CID}.csv"
     scp "${LOGIN}:${FILE_NAME}" "${DIR_PATH}"/"${NEW_FILE_NAME}"
     ssh "${LOGIN}" rm latency_*
-    scp "${LOGIN}:${PHY_FILE_NAME}" "${DIR_PATH}"/"${PHY_FILE_NAME}_${RUN_ID}_CID${CID}"
+    scp "${LOGIN}:${PHY_FILE_NAME}" "${DIR_PATH}"/"${PHY_FILE_NAME%.csv}_${RUN_ID}_CID${CID}.csv"
     ssh "${LOGIN}" rm rfsts.csv
   done


### PR DESCRIPTION
This pull request includes two changes: one updates the version of a Python package in the Dockerfile, and the other fixes a file naming issue in a helper script.

Dockerfile update:

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL16-R16): Downgraded the Flower package version from `1.18.0` to `1.15.2` in the installation step.

File naming fix:

* [`helper_scripts/transfer_latency_measurements.sh`](diffhunk://#diff-f87ce035bae1c8a14a3d1539ccbecf8fb350da402f355bbeba1082ccbad639d5L23-R23): Corrected the naming of transferred files by appending the `.csv` extension after modifying the file name.