### PR TITLE
64 create a docker container for serverapp to run trials

### DIFF
--- a/.github/workflows/trial-image.yml
+++ b/.github/workflows/trial-image.yml
@@ -1,0 +1,19 @@
+name: Build FL Trials Docker Image
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-trial:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      image_name: fl-trials
+      dockerfile_path: ./docker/trials/Dockerfile

--- a/docker/trials/Dockerfile
+++ b/docker/trials/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+# Set the working directory
+WORKDIR /app
+COPY ../../flwr-application /app/flwr-application
+COPY ../../helper_scripts /app/helper_scripts
+COPY ../../dist /app/dist
+COPY ../../util /app/util
+
+# Copy the requirements file into the container
+COPY ../../requirements.txt /app/
+RUN apt update && apt install -y \
+    build-essential \
+    curl \
+    openssh-client
+
+RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN pip install /app/dist/flwr-1.20.0-py3-none-any.whl
+
+ENV PYTHONPATH=/app
+
+RUN mkdir -p /app/experiments
+
+# Make helper scripts executable
+RUN chmod +x /app/helper_scripts/*.sh
+
+ENTRYPOINT ["/app/helper_scripts/run_trials.sh"]

--- a/docker/trials/Dockerfile
+++ b/docker/trials/Dockerfile
@@ -12,7 +12,8 @@ COPY ../../requirements.txt /app/
 RUN apt update && apt install -y \
     build-essential \
     curl \
-    openssh-client
+    openssh-client \
+    sshpass
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN pip install /app/dist/flwr-1.20.0-py3-none-any.whl

--- a/docker/trials/docker-compose.yml
+++ b/docker/trials/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  trials:
+    image: kmcomer/trials:latest
+    #privileged: true
+    volumes:
+    - ${HOME}/experiments:/app/experiments
+    command: 6 iid
+    network_mode: host


### PR DESCRIPTION
(Summary generated by Copilot)
This pull request introduces a new workflow and configuration for building and running a Docker image specifically for FL trials. The main changes include the addition of a GitHub Actions workflow to automate Docker image builds, a new Dockerfile for the FL trials environment, and a corresponding Docker Compose configuration for running the container.

**CI/CD Workflow Integration:**
* Added `.github/workflows/trial-image.yml` to automate building the FL trials Docker image on pull requests, pushes to `main`, and manual dispatches, using the shared `docker-build.yml` workflow.

**Docker Image for FL Trials:**
* Created `docker/trials/Dockerfile` to define a Python 3.12-based container for FL trials, including necessary dependencies, copying application files, and setting up the entrypoint for running trial scripts.

**Container Orchestration:**
* Added `docker/trials/docker-compose.yml` to configure the FL trials container, specifying the image, mounting the experiments directory, setting the command, and using host networking.